### PR TITLE
Relax numpy dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ vg>=0.5.0
 cached-property>=1.3.0
 lxml>=3.5.0
 matplotlib>=1.5.0
-numpy==1.15.1
+numpy>=1.15.1
 pyopengl>=3.1.0
 pyopengl_accelerate==3.1.3b1
 pyzmq>=15.1.0


### PR DESCRIPTION
This avoids a warning when installing lace with e.g. numpy 1.17.